### PR TITLE
Fix key press double counting

### DIFF
--- a/lib/typinggame.dart
+++ b/lib/typinggame.dart
@@ -150,7 +150,7 @@ class _TypingGamePageState extends State<TypingGamePage> {
   }
 
   double calculateAccuracy(){
-    return lengthSum / (numofKeyTouch / 2); // なぜかキータッチが2倍カウントされているので補正
+    return lengthSum / numofKeyTouch;
   }
 
   @override
@@ -206,14 +206,16 @@ class _TypingGamePageState extends State<TypingGamePage> {
             RawKeyboardListener(
               focusNode: _focusNode,
               onKey: (event) {
-                setState(() {
-                  key = event.logicalKey.keyLabel;
-                });
-                getWordfromTarget();
-                if(numofKeyTouch == 0){
-                  stopwatch.start();
+                if (event is RawKeyDownEvent) {
+                  setState(() {
+                    key = event.logicalKey.keyLabel;
+                  });
+                  getWordfromTarget();
+                  if (numofKeyTouch == 0) {
+                    stopwatch.start();
+                  }
+                  numofKeyTouch++;
                 }
-                numofKeyTouch ++;
               },
               child: Container(
                 width: 300,


### PR DESCRIPTION
## Summary
- count key presses only on RawKeyDown events
- remove temporary accuracy correction

## Testing
- `flutter test` *(fails: command not found)*
- `sudo apt-get install -y dart` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_689f0e3a5114832085a0558897e621d1